### PR TITLE
Add Slack PR comment and close actions.

### DIFF
--- a/.github/workflows/pr-action-buttons.yml
+++ b/.github/workflows/pr-action-buttons.yml
@@ -1,0 +1,45 @@
+name: PR Action Buttons
+
+on:
+  pull_request:
+    types:
+      - opened
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  add-pr-buttons:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add PR action buttons comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const number = pr.number;
+
+            const commentUrl = `${pr.html_url}#new_comment_field`;
+            const editUrl = `${pr.html_url}/edit`;
+            const closeUrl = `${pr.html_url}`;
+
+            const body = [
+              "## Pull Request Quick Actions",
+              "",
+              `[![Comment](https://img.shields.io/badge/Comment-0969DA?style=for-the-badge&logo=github&logoColor=white)](${commentUrl})`,
+              `[![Edit](https://img.shields.io/badge/Edit-8250DF?style=for-the-badge&logo=github&logoColor=white)](${editUrl})`,
+              `[![Close](https://img.shields.io/badge/Close-D1242F?style=for-the-badge&logo=github&logoColor=white)](${closeUrl})`,
+              "",
+              "_Use **Close** to open the PR page, then click **Close pull request** in the GitHub UI._"
+            ].join("\n");
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: number,
+              body
+            });

--- a/.github/workflows/slack-approval-test.yml
+++ b/.github/workflows/slack-approval-test.yml
@@ -10,6 +10,11 @@ on:
       - synchronize
       - reopened
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 jobs:
   approval:
     runs-on: ubuntu-latest
@@ -25,6 +30,7 @@ jobs:
       - name: slack-approval
         uses: ./
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_APP_TOKEN: ${{ secrets.SLACK_APP_TOKEN }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           SLACK_SIGNING_SECRET: ${{ secrets.SLACK_SIGNING_SECRET }}

--- a/dist/index.js
+++ b/dist/index.js
@@ -34,6 +34,7 @@ var __importStar = (this && this.__importStar) || (function () {
 })();
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(require("@actions/core"));
+const github = __importStar(require("@actions/github"));
 const bolt_1 = require("@slack/bolt");
 const web_api_1 = require("@slack/web-api");
 const token = process.env.SLACK_BOT_TOKEN || "";
@@ -41,6 +42,7 @@ const signingSecret = process.env.SLACK_SIGNING_SECRET || "";
 const slackAppToken = process.env.SLACK_APP_TOKEN || "";
 const channel_id = process.env.SLACK_CHANNEL_ID || "";
 const customBlocks = core.getInput('custom-blocks') || "[]";
+const githubToken = process.env.GITHUB_TOKEN || "";
 const app = new bolt_1.App({
     token: token,
     signingSecret: signingSecret,
@@ -59,6 +61,11 @@ async function run() {
         const workflow = process.env.GITHUB_WORKFLOW || "";
         const runnerOS = process.env.RUNNER_OS || "";
         const actor = process.env.GITHUB_ACTOR || "";
+        const repository = process.env.GITHUB_REPOSITORY || "";
+        const ref = process.env.GITHUB_REF || "";
+        const prMatch = ref.match(/^refs\/pull\/(\d+)\/(merge|head)$/);
+        const prNumber = prMatch ? Number(prMatch[1]) : undefined;
+        const [owner, repo] = repository.split("/");
         // Parse custom blocks
         let parsedCustomBlocks = [];
         try {
@@ -117,6 +124,16 @@ async function run() {
                         "text": {
                             "type": "plain_text",
                             "emoji": true,
+                            "text": "Comment"
+                        },
+                        "value": "comment",
+                        "action_id": "slack-approval-comment"
+                    },
+                    {
+                        "type": "button",
+                        "text": {
+                            "type": "plain_text",
+                            "emoji": true,
                             "text": "Approve"
                         },
                         "style": "primary",
@@ -133,6 +150,17 @@ async function run() {
                         "style": "danger",
                         "value": "reject",
                         "action_id": "slack-approval-reject"
+                    },
+                    {
+                        "type": "button",
+                        "text": {
+                            "type": "plain_text",
+                            "emoji": true,
+                            "text": "Close PR"
+                        },
+                        "style": "danger",
+                        "value": "close-pr",
+                        "action_id": "slack-approval-close-pr"
                     }
                 ]
             };
@@ -190,6 +218,131 @@ async function run() {
             }
             catch (error) {
                 logger.error(error);
+            }
+            process.exit(1);
+        });
+        app.action('slack-approval-comment', async ({ ack, body, client, logger }) => {
+            await ack();
+            try {
+                if (!owner || !repo || !prNumber) {
+                    throw new Error("This workflow is not running in pull_request context, cannot determine PR to comment on.");
+                }
+                const metadata = JSON.stringify({
+                    owner,
+                    repo,
+                    prNumber
+                });
+                await client.views.open({
+                    trigger_id: body.trigger_id,
+                    view: {
+                        type: "modal",
+                        callback_id: "slack-approval-comment-submit",
+                        private_metadata: metadata,
+                        title: {
+                            type: "plain_text",
+                            text: "Comment on PR"
+                        },
+                        submit: {
+                            type: "plain_text",
+                            text: "Post"
+                        },
+                        close: {
+                            type: "plain_text",
+                            text: "Cancel"
+                        },
+                        blocks: [
+                            {
+                                type: "input",
+                                block_id: "github-comment-block",
+                                label: {
+                                    type: "plain_text",
+                                    text: "Comment"
+                                },
+                                element: {
+                                    type: "plain_text_input",
+                                    action_id: "github-comment-input",
+                                    multiline: true
+                                }
+                            }
+                        ]
+                    }
+                });
+            }
+            catch (error) {
+                logger.error(error);
+            }
+        });
+        app.view('slack-approval-comment-submit', async ({ ack, body, view, client, logger }) => {
+            await ack();
+            try {
+                if (!githubToken) {
+                    throw new Error("GITHUB_TOKEN is required to create pull request comments from Slack.");
+                }
+                const metadata = JSON.parse(view.private_metadata || "{}");
+                const modalOwner = metadata.owner || owner;
+                const modalRepo = metadata.repo || repo;
+                const modalPrNumber = metadata.prNumber || prNumber;
+                if (!modalOwner || !modalRepo || !modalPrNumber) {
+                    throw new Error("Could not determine the target pull request for the comment.");
+                }
+                const commentText = view.state.values["github-comment-block"]["github-comment-input"].value?.trim();
+                if (!commentText) {
+                    throw new Error("Comment text is empty.");
+                }
+                const octokit = github.getOctokit(githubToken);
+                await octokit.rest.issues.createComment({
+                    owner: modalOwner,
+                    repo: modalRepo,
+                    issue_number: modalPrNumber,
+                    body: commentText
+                });
+                await client.chat.postEphemeral({
+                    channel: channel_id,
+                    user: body.user.id,
+                    text: `Posted your comment to PR #${modalPrNumber}.`
+                });
+            }
+            catch (error) {
+                logger.error(error);
+            }
+        });
+        app.action('slack-approval-close-pr', async ({ ack, client, body, logger }) => {
+            await ack();
+            try {
+                if (!githubToken) {
+                    throw new Error("GITHUB_TOKEN is required to close pull requests from Slack.");
+                }
+                if (!repository || !prNumber) {
+                    throw new Error("This workflow is not running in pull_request context, cannot determine PR to close.");
+                }
+                if (!owner || !repo) {
+                    throw new Error(`Invalid GITHUB_REPOSITORY value: ${repository}`);
+                }
+                const octokit = github.getOctokit(githubToken);
+                await octokit.rest.pulls.update({
+                    owner,
+                    repo,
+                    pull_number: prNumber,
+                    state: "closed"
+                });
+                const response_blocks = body.message?.blocks;
+                response_blocks.pop();
+                response_blocks.push({
+                    'type': 'section',
+                    'text': {
+                        'type': 'mrkdwn',
+                        'text': `Pull request #${prNumber} closed by <@${body.user.id}>`,
+                    },
+                });
+                await client.chat.update({
+                    channel: body.channel?.id || "",
+                    ts: body.message?.ts || "",
+                    blocks: response_blocks
+                });
+            }
+            catch (error) {
+                logger.error(error);
+                core.setFailed(error instanceof Error ? error.message : 'Failed to close pull request');
             }
             process.exit(1);
         });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import * as core from '@actions/core'
 import * as github from '@actions/github'
+import * as fs from 'fs'
 import { App, BlockAction, LogLevel } from '@slack/bolt'
 import { WebClient } from '@slack/web-api'
 import { KnownBlock, Block } from '@slack/types'
@@ -33,10 +34,32 @@ async function run(): Promise<void> {
     const actor      = process.env.GITHUB_ACTOR || "";
     const repository = process.env.GITHUB_REPOSITORY || "";
     const ref        = process.env.GITHUB_REF || "";
+    const eventPath  = process.env.GITHUB_EVENT_PATH || "";
 
     const prMatch = ref.match(/^refs\/pull\/(\d+)\/(merge|head)$/);
-    const prNumber = prMatch ? Number(prMatch[1]) : undefined;
+    let prNumber = prMatch ? Number(prMatch[1]) : undefined;
     const [owner, repo] = repository.split("/");
+    let prHtmlUrl = prNumber ? `${github_server_url}/${github_repos}/pull/${prNumber}` : `${github_server_url}/${github_repos}`;
+
+    // Fallback to event payload for more reliable PR metadata.
+    try {
+      if (eventPath) {
+        const eventPayload = JSON.parse(fs.readFileSync(eventPath, 'utf8')) as {
+          pull_request?: {
+            number?: number
+            html_url?: string
+          }
+        };
+        if (!prNumber && eventPayload.pull_request?.number) {
+          prNumber = eventPayload.pull_request.number;
+        }
+        if (eventPayload.pull_request?.html_url) {
+          prHtmlUrl = eventPayload.pull_request.html_url;
+        }
+      }
+    } catch (error) {
+      console.warn('Failed to parse GITHUB_EVENT_PATH payload:', error);
+    }
 
     // Parse custom blocks
     let parsedCustomBlocks: (KnownBlock | Block)[] = [];
@@ -101,6 +124,17 @@ async function run(): Promise<void> {
                   },
                   "value": "comment",
                   "action_id": "slack-approval-comment"
+              },
+              {
+                  "type": "button",
+                  "text": {
+                          "type": "plain_text",
+                          "emoji": true,
+                          "text": "Edit PR"
+                  },
+                  "url": `${prHtmlUrl}/edit`,
+                  "value": "edit-pr",
+                  "action_id": "slack-approval-edit-pr"
               },
               {
                   "type": "button",
@@ -211,7 +245,8 @@ async function run(): Promise<void> {
         const metadata = JSON.stringify({
           owner,
           repo,
-          prNumber
+          prNumber,
+          channelId: body.channel?.id
         });
 
         await client.views.open({
@@ -265,14 +300,19 @@ async function run(): Promise<void> {
           owner?: string
           repo?: string
           prNumber?: number
+          channelId?: string
         };
 
         const modalOwner = metadata.owner || owner;
         const modalRepo = metadata.repo || repo;
         const modalPrNumber = metadata.prNumber || prNumber;
+        const modalChannelId = metadata.channelId || channel_id;
 
         if (!modalOwner || !modalRepo || !modalPrNumber) {
           throw new Error("Could not determine the target pull request for the comment.");
+        }
+        if (!modalChannelId) {
+          throw new Error("Could not determine Slack channel for confirmation message.");
         }
 
         const commentText = view.state.values["github-comment-block"]["github-comment-input"].value?.trim();
@@ -289,7 +329,7 @@ async function run(): Promise<void> {
         });
 
         await client.chat.postEphemeral({
-          channel: channel_id,
+          channel: modalChannelId,
           user: body.user.id,
           text: `Posted your comment to PR #${modalPrNumber}.`
         });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import * as core from '@actions/core'
+import * as github from '@actions/github'
 import { App, BlockAction, LogLevel } from '@slack/bolt'
 import { WebClient } from '@slack/web-api'
 import { KnownBlock, Block } from '@slack/types'
@@ -8,6 +9,7 @@ const signingSecret =  process.env.SLACK_SIGNING_SECRET || ""
 const slackAppToken = process.env.SLACK_APP_TOKEN || ""
 const channel_id    = process.env.SLACK_CHANNEL_ID || ""
 const customBlocks  = core.getInput('custom-blocks') || "[]"
+const githubToken   = process.env.GITHUB_TOKEN || ""
 
 const app = new App({
   token: token,
@@ -29,6 +31,12 @@ async function run(): Promise<void> {
     const workflow   = process.env.GITHUB_WORKFLOW || "";
     const runnerOS   = process.env.RUNNER_OS || "";
     const actor      = process.env.GITHUB_ACTOR || "";
+    const repository = process.env.GITHUB_REPOSITORY || "";
+    const ref        = process.env.GITHUB_REF || "";
+
+    const prMatch = ref.match(/^refs\/pull\/(\d+)\/(merge|head)$/);
+    const prNumber = prMatch ? Number(prMatch[1]) : undefined;
+    const [owner, repo] = repository.split("/");
 
     // Parse custom blocks
     let parsedCustomBlocks: (KnownBlock | Block)[] = [];
@@ -89,6 +97,16 @@ async function run(): Promise<void> {
                   "text": {
                       "type": "plain_text",
                       "emoji": true,
+                      "text": "Comment"
+                  },
+                  "value": "comment",
+                  "action_id": "slack-approval-comment"
+              },
+              {
+                  "type": "button",
+                  "text": {
+                      "type": "plain_text",
+                      "emoji": true,
                       "text": "Approve"
                   },
                   "style": "primary",
@@ -105,6 +123,17 @@ async function run(): Promise<void> {
                   "style": "danger",
                   "value": "reject",
                   "action_id": "slack-approval-reject"
+              },
+              {
+                  "type": "button",
+                  "text": {
+                          "type": "plain_text",
+                          "emoji": true,
+                          "text": "Close PR"
+                  },
+                  "style": "danger",
+                  "value": "close-pr",
+                  "action_id": "slack-approval-close-pr"
               }
           ]
       };
@@ -167,6 +196,149 @@ async function run(): Promise<void> {
         })
       } catch (error) {
         logger.error(error)
+      }
+
+      process.exit(1)
+    });
+
+    app.action('slack-approval-comment', async ({ack, body, client, logger}) => {
+      await ack();
+      try {
+        if (!owner || !repo || !prNumber) {
+          throw new Error("This workflow is not running in pull_request context, cannot determine PR to comment on.");
+        }
+
+        const metadata = JSON.stringify({
+          owner,
+          repo,
+          prNumber
+        });
+
+        await client.views.open({
+          trigger_id: (<BlockAction>body).trigger_id,
+          view: {
+            type: "modal",
+            callback_id: "slack-approval-comment-submit",
+            private_metadata: metadata,
+            title: {
+              type: "plain_text",
+              text: "Comment on PR"
+            },
+            submit: {
+              type: "plain_text",
+              text: "Post"
+            },
+            close: {
+              type: "plain_text",
+              text: "Cancel"
+            },
+            blocks: [
+              {
+                type: "input",
+                block_id: "github-comment-block",
+                label: {
+                  type: "plain_text",
+                  text: "Comment"
+                },
+                element: {
+                  type: "plain_text_input",
+                  action_id: "github-comment-input",
+                  multiline: true
+                }
+              }
+            ]
+          }
+        });
+      } catch (error) {
+        logger.error(error);
+      }
+    });
+
+    app.view('slack-approval-comment-submit', async ({ack, body, view, client, logger}) => {
+      await ack();
+      try {
+        if (!githubToken) {
+          throw new Error("GITHUB_TOKEN is required to create pull request comments from Slack.");
+        }
+
+        const metadata = JSON.parse(view.private_metadata || "{}") as {
+          owner?: string
+          repo?: string
+          prNumber?: number
+        };
+
+        const modalOwner = metadata.owner || owner;
+        const modalRepo = metadata.repo || repo;
+        const modalPrNumber = metadata.prNumber || prNumber;
+
+        if (!modalOwner || !modalRepo || !modalPrNumber) {
+          throw new Error("Could not determine the target pull request for the comment.");
+        }
+
+        const commentText = view.state.values["github-comment-block"]["github-comment-input"].value?.trim();
+        if (!commentText) {
+          throw new Error("Comment text is empty.");
+        }
+
+        const octokit = github.getOctokit(githubToken);
+        await octokit.rest.issues.createComment({
+          owner: modalOwner,
+          repo: modalRepo,
+          issue_number: modalPrNumber,
+          body: commentText
+        });
+
+        await client.chat.postEphemeral({
+          channel: channel_id,
+          user: body.user.id,
+          text: `Posted your comment to PR #${modalPrNumber}.`
+        });
+      } catch (error) {
+        logger.error(error);
+      }
+    });
+
+    app.action('slack-approval-close-pr', async ({ack, client, body, logger}) => {
+      await ack();
+      try {
+        if (!githubToken) {
+          throw new Error("GITHUB_TOKEN is required to close pull requests from Slack.");
+        }
+
+        if (!repository || !prNumber) {
+          throw new Error("This workflow is not running in pull_request context, cannot determine PR to close.");
+        }
+
+        if (!owner || !repo) {
+          throw new Error(`Invalid GITHUB_REPOSITORY value: ${repository}`);
+        }
+
+        const octokit = github.getOctokit(githubToken);
+        await octokit.rest.pulls.update({
+          owner,
+          repo,
+          pull_number: prNumber,
+          state: "closed"
+        });
+
+        const response_blocks = (<BlockAction>body).message?.blocks
+        response_blocks.pop()
+        response_blocks.push({
+          'type': 'section',
+          'text': {
+            'type': 'mrkdwn',
+            'text': `Pull request #${prNumber} closed by <@${body.user.id}>`,
+          },
+        })
+
+        await client.chat.update({
+          channel: body.channel?.id || "",
+          ts: (<BlockAction>body).message?.ts || "",
+          blocks: response_blocks
+        })
+      } catch (error) {
+        logger.error(error)
+        core.setFailed(error instanceof Error ? error.message : 'Failed to close pull request');
       }
 
       process.exit(1)


### PR DESCRIPTION
Support entering PR comments in a Slack modal and posting them to GitHub, and add a Close PR action with required workflow permissions.